### PR TITLE
Ticket#10 - adds comment_count to function fetchArticlesAll query

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -109,12 +109,14 @@ describe('GET - requests testing', () => {
                 .then(({ body: { articles } }) => {
                     articles.forEach((article) => {
                         expect(article).toEqual(expect.objectContaining({
+                            article_id: expect.any(Number),
                             title: expect.any(String),
                             topic: expect.any(String),
                             author: expect.any(String),
                             body: expect.any(String),
                             created_at: expect.any(String),
                             votes: expect.any(Number),
+                            comment_count: expect.any(Number),
                         }))
                     })
                 })

--- a/models/get-models.js
+++ b/models/get-models.js
@@ -9,7 +9,11 @@ exports.fetchTopicsAll = () => {
 }
 
 exports.fetchArticlesAll = () => {
-    return db.query('SELECT * FROM articles;')
+
+    const str = `SELECT articles.*, CAST(COUNT(comments.article_id)AS INT) AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id;`
+
+    return db.query(str)
+
         .then(({ rows }) => {
             return rows
         })


### PR DESCRIPTION
`SELECT articles.*, CAST(COUNT(comments.article_id)AS INT) AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id GROUP BY articles.article_id;`